### PR TITLE
feat: add a default value for `resource_name_prefix`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,7 @@ variable "resource_group" {
 }
 
 variable "resource_name_prefix" {
+  default     = "dev"
   description = "Prefix applied to resource names"
   type        = string
 }


### PR DESCRIPTION
this is done so that the variable becomes optional

closes #1